### PR TITLE
Change background and text colors on div.notice

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -22,8 +22,8 @@ body {
 }
 
 .notice {
-  background: #663399;
-  color: #F62459;
+  background: rgba(51, 76, 153, 0.37);
+  color: #aa193e;
   padding: 10px 0px 10px 0px;
   margin: 0;
   width: 100%;


### PR DESCRIPTION
It was janky but readable on a laptop screen, but really, genuinely tough to make anything out when projected onto the big screen during talks.

So:
* Change the background color from bright purple to a subtler semi-transparent
shade. Also slightly bluer than before to reduce contrast and increase
readability.
* Make the writing a duller shade of red. It still reads as 'red', but less harsh.

### Before:
<img width="650" alt="screen shot 2015-12-17 at 10 44 19 am" src="https://cloud.githubusercontent.com/assets/7516653/11878561/6d0e4be8-a4ab-11e5-9831-0068e48959dc.png">

### After:
<img width="677" alt="screen shot 2015-12-17 at 10 43 16 am" src="https://cloud.githubusercontent.com/assets/7516653/11878567/761335b4-a4ab-11e5-9bbc-7682100083c1.png">